### PR TITLE
fixed time showing wrong

### DIFF
--- a/src/views/AdminViews/AvailabilityViews/AvailabilityAdd.vue
+++ b/src/views/AdminViews/AvailabilityViews/AvailabilityAdd.vue
@@ -398,7 +398,7 @@ import Utils from '@/config/utils.js'
         // see if selected dates includes today -- if not, allow all times
         const test = this.dates.filter(date => date === this.nowDate);
         if (test.length > 0) {
-          this.nowTime =  temp.getHours() + ":" + temp.getMinutes();
+          this.nowTime =  temp.toString().slice(16,21);
         }
         else {
           this.nowTime = "00:00"


### PR DESCRIPTION
Fixed the availability time selects showing 3:0 instead of 3:00. The issue was that Date.getMinutes() returns an integer between 0-59, so 00 was not displaying.