### PR TITLE
We had a ticket about a cancelled appointment being set as available.

### DIFF
--- a/src/views/CalendarViews/MainCalendar.vue
+++ b/src/views/CalendarViews/MainCalendar.vue
@@ -815,7 +815,7 @@ import Utils from '@/config/utils.js'
         }
       } else {
         // don't need to update google cal because it's not even on there yet
-        this.selectedAppointment.status = "cancelled"
+        this.selectedAppointment.status = "tutorCancel"
         await AppointmentServices.updateAppointment(this.selectedAppointment.id, this.selectedAppointment).then(() =>{
           this.getAppointments()
           this.selectedEvent.color = 'red'


### PR DESCRIPTION
I found that there was one place where appointments were being saved as "cancelled" but we only use "studentCancel" and "tutorCancel" now. That's why the appointment was showing up incorrectly.