### PR TITLE
finished adding fixes for booking past start time

### DIFF
--- a/src/views/CalendarViews/MainCalendar.vue
+++ b/src/views/CalendarViews/MainCalendar.vue
@@ -922,9 +922,9 @@ import Utils from '@/config/utils.js'
               personId: t.id
             }
             await PersonAppointmentServices.addPersonAppointment(pap)
-          })
-          .catch (error => {
-            this.message = error.response.data.message
+            .catch (error => {
+              this.message = error.response.data.message
+            })
           })
         })
         .catch (error => {
@@ -956,9 +956,9 @@ import Utils from '@/config/utils.js'
                this.message = error.response.data.message
              })
           })
-          .catch (error => {
-          this.message = error.response.data.message
         })
+        .catch (error => {
+          this.message = error.response.data.message
         })
       }
       //Load appointment info
@@ -1937,7 +1937,23 @@ import Utils from '@/config/utils.js'
       checkDate.setHours(0,0,0,0);
       let checkTime = new Date();
       let tempHours = checkTime.getHours();
+      // check minutes for group's booking buffer
       let tempMins = checkTime.getMinutes();
+      if(this.checkRole('Admin') && this.group.bookPastMinutes > 0) {
+        tempMins -= this.group.bookPastMinutes;
+        if(tempMins < 0) {
+          tempMins += 60
+          tempHours--;
+        }
+      }
+      else if(this.group.bookPastMinutes < 0) {
+        tempMins -= this.group.bookPastMinutes;
+        if(tempMins > 59) {
+          tempMins -= 60;
+          tempHours++;
+        }
+      }
+      console.log(tempMins)
       let tempSecs = checkTime.getSeconds();
       if(tempHours < 10)
       {
@@ -1965,6 +1981,7 @@ import Utils from '@/config/utils.js'
       else {
         this.datePast = false;
       }
+      console.log(this.datePast)
     },
   },
 }

--- a/src/views/CalendarViews/MainCalendar.vue
+++ b/src/views/CalendarViews/MainCalendar.vue
@@ -1941,14 +1941,14 @@ import Utils from '@/config/utils.js'
       let tempMins = checkTime.getMinutes();
       if(this.checkRole('Admin') && this.group.bookPastMinutes > 0) {
         tempMins -= this.group.bookPastMinutes;
-        if(tempMins < 0) {
+        while(tempMins < 0) {
           tempMins += 60
           tempHours--;
         }
       }
       else if(this.group.bookPastMinutes < 0) {
         tempMins -= this.group.bookPastMinutes;
-        if(tempMins > 59) {
+        while(tempMins > 59) {
           tempMins -= 60;
           tempHours++;
         }


### PR DESCRIPTION
Admins can book students for appointments that are past the start time. Anyone may be restricted from booking an appointment if a group sets a buffer beforehand.

I also may have fixed the issue where the book button is clicked, but the appointment isn't booked. I think this was because there were a few catches in the splitAppointmentForAdminAdd function that did not apply to what they were linked to, causing an error.